### PR TITLE
Fix default build errors

### DIFF
--- a/docs/kos/README.md
+++ b/docs/kos/README.md
@@ -1,1 +1,8 @@
 # Kaspersky OS support
+
+
+## Build
+
+```bash
+$ make TARGETOS=kos TARGETARCH=arm64
+```

--- a/pkg/report/kos.go
+++ b/pkg/report/kos.go
@@ -1,0 +1,36 @@
+package report
+
+import "path/filepath"
+
+type kos struct {
+	*config
+}
+
+func ctorKOS(cfg *config) (reporterImpl, []string, error) {
+	ctx := &fuchsia{
+		config: cfg,
+	}
+	if ctx.kernelObj != "" {
+		ctx.obj = filepath.Join(ctx.kernelObj, ctx.target.KernelObject)
+	}
+	suppressions := []string{
+		"fatal exception: process /tmp/syz-fuzzer", // OOM presumably
+	}
+	return ctx, suppressions, nil
+}
+
+func (k *kos) ContainsCrash(output []byte) bool {
+	// TODO: implement logic to read kos kernel console output messages
+	return false
+}
+
+func (k *kos) Parse(output []byte) *Report {
+	// TODO: imeplement kos kernel console output parsing
+	return nil
+
+}
+
+func (k *kos) Symbolize(rep *Report) error {
+	// TODO: Implementation
+	return nil
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -157,6 +157,7 @@ var ctors = map[string]fn{
 	targets.OpenBSD: ctorOpenbsd,
 	targets.Fuchsia: ctorFuchsia,
 	targets.Windows: ctorStub,
+	targets.KOS:     ctorKOS,
 }
 
 type config struct {

--- a/sys/kos/gen/empty.go
+++ b/sys/kos/gen/empty.go
@@ -1,0 +1,6 @@
+// Copyright 2021 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
+package gen
+
+// Empty file to unbreak build while descriptions are not generated.

--- a/sys/sys.go
+++ b/sys/sys.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/google/syzkaller/sys/darwin/gen"
 	_ "github.com/google/syzkaller/sys/freebsd/gen"
 	_ "github.com/google/syzkaller/sys/fuchsia/gen"
+	_ "github.com/google/syzkaller/sys/kos/gen"
 	_ "github.com/google/syzkaller/sys/linux/gen"
 	_ "github.com/google/syzkaller/sys/netbsd/gen"
 	_ "github.com/google/syzkaller/sys/openbsd/gen"

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -240,7 +240,16 @@ var archConfigs = map[string]*archConfig{
 		NetDev:   "e1000",
 		RngDev:   "virtio-rng-pci",
 	},
+	"kos/arm64": {
+		Qemu:      "qemu-system-arm", // qemu binary comming with kos toolchain
+		QemuArgs:  "-machine vexpress-a15 -nographic -monitor none -serial stdio -serial",
+		TargetDir: "/tmp",
+		NetDev:    "e1000",
+		RngDev:    "virtio-rng-pci",
+	},
 }
+
+//  tcp::12345,server,nowait -s -S -kernel /home/behouba/kos-examples/gpio_input/build/einit/kos-qemu-image
 
 func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	archConfig := archConfigs[env.OS+"/"+env.Arch]


### PR DESCRIPTION
I forgot to add `empty.go` file inside `sys/kos/gen` to make it possible to unbreak build while descriptions are not generated. 