### PR TITLE
Add instructions to build kos image manually

### DIFF
--- a/docs/kos/README.md
+++ b/docs/kos/README.md
@@ -1,7 +1,71 @@
 # Kaspersky OS support
 
 
-## Build
+Kaspersky OS Community Edition is available [here](https://os.kaspersky.com/download-community-edition/). 
+
+KasperskyOS Community Edition is distributed as a DEB package that you will need to install (follow the instructions on the [Getting started](https://support.kaspersky.com/help/KCE/1.0/en-US/getting_started.htm) page).
+
+In the instructions below, the $VAR notation (e.g. $GCC, $KERNEL, etc.) is used to denote paths to directories.
+
+- $IMAGE: Kaspersky OS kernel image directory
+- $KOSPATH: Installation path of Kaspersky OS (/opt/KasperskyOS-Community-Edition-{version})
+- $SYZKALLER: Syzkaller directory
+
+
+## Build Kaspersky OS image
+
+### 1. Create a directory to build Kaspersky OS image
+
+```bash
+$ mkdir $IMAGE && cd $IMAGE
+```
+
+### 2. Create the files from `$SYZKALLER/executor/kos` folder into `$IMAGE` folder
+
+```bash
+$ cp $SYZKALLER/executor/kos/* .
+```
+
+### 3. Build the einit entity
+
+Generate the code of the Einit entity in C 
+
+```bash
+$ einit -I $KOSPATH/sysroot-arm-kos/include \
+-I $KOSPATH/toolchain/arm-kos/include \
+-I $KOSPATH/toolchain/include \
+-I . -o einit.c init.yaml
+```
+
+A file named `einit.c` will be generated.
+
+
+Compile the `einit.c` file into the executable file of the Einit entity
+
+```bash
+$ arm-kos-gcc einit.c -o Einit
+```
+
+### 4. Build syz-executor for Kaspersky OS (TODO: when executor for kos is implemented)
+
+
+### 5. Build Kaspersky OS qemu image with executor binary
+
+Run the following command to build Kaspersky OS qemu image:
+
+```bash
+$ makeimg \
+ --target=arm-kos --sys-root=$KOSPATH/sysroot-arm-kos \
+ --with-toolchain=$KOSPATH/toolchain \
+ --ldscript=$KOSPATH/sysroot-arm-kos/../libexec/arm-kos/kos-qemu.ld \
+ --img-src=$KOSPATH/sysroot-arm-kos/../libexec/arm-kos/kos-qemu \
+ --with-init=Einit \
+ --img-dst=kos-image \
+ /path/to/executor
+```
+
+
+## Build syzkaller for Kaspersky OS
 
 ```bash
 $ make TARGETOS=kos TARGETARCH=arm64

--- a/docs/kos/README.md
+++ b/docs/kos/README.md
@@ -5,7 +5,7 @@ Kaspersky OS Community Edition is available [here](https://os.kaspersky.com/down
 
 KasperskyOS Community Edition is distributed as a DEB package that you will need to install (follow the instructions on the [Getting started](https://support.kaspersky.com/help/KCE/1.0/en-US/getting_started.htm) page).
 
-In the instructions below, the $VAR notation (e.g. $GCC, $KERNEL, etc.) is used to denote paths to directories.
+In the instructions below, the $VAR notation is used to denote paths to directories:
 
 - $IMAGE: Kaspersky OS kernel image directory
 - $KOSPATH: Installation path of Kaspersky OS (/opt/KasperskyOS-Community-Edition-{version})

--- a/docs/kos/README.md
+++ b/docs/kos/README.md
@@ -1,7 +1,7 @@
 # Kaspersky OS support
 
 
-Kaspersky OS Community Edition is available [here](https://os.kaspersky.com/download-community-edition/). 
+Kaspersky OS Community Edition is available [here](https://os.kaspersky.com/download-community-edition/).
 
 KasperskyOS Community Edition is distributed as a DEB package that you will need to install (follow the instructions on the [Getting started](https://support.kaspersky.com/help/KCE/1.0/en-US/getting_started.htm) page).
 
@@ -28,7 +28,7 @@ $ cp $SYZKALLER/executor/kos/* .
 
 ### 3. Build the einit entity
 
-Generate the code of the Einit entity in C 
+Generate the code of the Einit entity in C
 
 ```bash
 $ einit -I $KOSPATH/sysroot-arm-kos/include \

--- a/executor/kos/Executor.cdl
+++ b/executor/kos/Executor.cdl
@@ -1,0 +1,1 @@
+package Executor

--- a/executor/kos/Executor.edl
+++ b/executor/kos/Executor.edl
@@ -1,0 +1,1 @@
+entity Executor

--- a/executor/kos/Executor.idl
+++ b/executor/kos/Executor.idl
@@ -1,0 +1,1 @@
+package Executor

--- a/executor/kos/init.yml
+++ b/executor/kos/init.yml
@@ -1,3 +1,6 @@
+# Copyright 2018 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
 entities:
 
 - name: Executor

--- a/executor/kos/init.yml
+++ b/executor/kos/init.yml
@@ -2,5 +2,4 @@
 # Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
 
 entities:
-
 - name: Executor

--- a/executor/kos/init.yml
+++ b/executor/kos/init.yml
@@ -1,0 +1,3 @@
+entities:
+
+- name: Executor

--- a/pkg/report/kos.go
+++ b/pkg/report/kos.go
@@ -1,3 +1,6 @@
+// Copyright 2018 syzkaller project authors. All rights reserved.
+// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+
 package report
 
 import "path/filepath"

--- a/pkg/report/kos.go
+++ b/pkg/report/kos.go
@@ -34,6 +34,6 @@ func (k *kos) Parse(output []byte) *Report {
 }
 
 func (k *kos) Symbolize(rep *Report) error {
-	// TODO: Implementation
+	// TODO
 	return nil
 }

--- a/pkg/report/kos.go
+++ b/pkg/report/kos.go
@@ -7,10 +7,11 @@ import "path/filepath"
 
 type kos struct {
 	*config
+	obj string
 }
 
 func ctorKOS(cfg *config) (reporterImpl, []string, error) {
-	ctx := &fuchsia{
+	ctx := &kos{
 		config: cfg,
 	}
 	if ctx.kernelObj != "" {
@@ -30,7 +31,6 @@ func (k *kos) ContainsCrash(output []byte) bool {
 func (k *kos) Parse(output []byte) *Report {
 	// TODO: imeplement kos kernel console output parsing
 	return nil
-
 }
 
 func (k *kos) Symbolize(rep *Report) error {

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -241,7 +241,7 @@ var archConfigs = map[string]*archConfig{
 		RngDev:   "virtio-rng-pci",
 	},
 	"kos/arm64": {
-		Qemu:                   "/opt/KasperskyOS-Community-Edition-1.0.1.4/toolchain/bin/qemu-system-arm", // qemu binary comming with kos toolchain
+		Qemu:                   "qemu-system-arm", // Or qemu binary comming with kos toolchain
 		QemuArgs:               "-machine vexpress-a15 -cpu max",
 		NetDev:                 "virtio-net-device",
 		RngDev:                 "virtio-rng-device",
@@ -253,8 +253,6 @@ var archConfigs = map[string]*archConfig{
 		},
 	},
 }
-
-//  /opt/KasperskyOS-Community-Edition-1.0.1.4/toolchain/bin/qemu-system-arm -m 2048 -machine vexpress-a15 -nographic -monitor none -serial stdio -kernel /home/behouba/kos-examples/hello/build/einit/kos-qemu-image
 
 func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	archConfig := archConfigs[env.OS+"/"+env.Arch]

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -241,7 +241,7 @@ var archConfigs = map[string]*archConfig{
 		RngDev:   "virtio-rng-pci",
 	},
 	"kos/arm64": {
-		Qemu:                   "qemu-system-arm", // Or qemu binary comming with kos toolchain
+		Qemu:                   "qemu-system-arm", // Or qemu binary coming with kos toolchain
 		QemuArgs:               "-machine vexpress-a15 -cpu max",
 		NetDev:                 "virtio-net-device",
 		RngDev:                 "virtio-rng-device",

--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -241,15 +241,20 @@ var archConfigs = map[string]*archConfig{
 		RngDev:   "virtio-rng-pci",
 	},
 	"kos/arm64": {
-		Qemu:      "qemu-system-arm", // qemu binary comming with kos toolchain
-		QemuArgs:  "-machine vexpress-a15 -nographic -monitor none -serial stdio -serial",
-		TargetDir: "/tmp",
-		NetDev:    "e1000",
-		RngDev:    "virtio-rng-pci",
+		Qemu:                   "/opt/KasperskyOS-Community-Edition-1.0.1.4/toolchain/bin/qemu-system-arm", // qemu binary comming with kos toolchain
+		QemuArgs:               "-machine vexpress-a15 -cpu max",
+		NetDev:                 "virtio-net-device",
+		RngDev:                 "virtio-rng-device",
+		UseNewQemuImageOptions: true,
+		// TargetDir:              "/tmp",
+		CmdLine: []string{
+			"root=/dev/vda",
+			"console=ttyAMA0",
+		},
 	},
 }
 
-//  tcp::12345,server,nowait -s -S -kernel /home/behouba/kos-examples/gpio_input/build/einit/kos-qemu-image
+//  /opt/KasperskyOS-Community-Edition-1.0.1.4/toolchain/bin/qemu-system-arm -m 2048 -machine vexpress-a15 -nographic -monitor none -serial stdio -kernel /home/behouba/kos-examples/hello/build/einit/kos-qemu-image
 
 func ctor(env *vmimpl.Env) (vmimpl.Pool, error) {
 	archConfig := archConfigs[env.OS+"/"+env.Arch]


### PR DESCRIPTION
Added instruction to build kos image manually with eventully executable files. 
We will need to have executor entity ready for kos for the this to be complete. 
Let try to build the image with executor inside manually for now. 
After that, I think it will be more easier to write the script to implement the `builder interface` for kos inside: `pkg/build/kos.go`